### PR TITLE
Feature/ Add support for forwarding approval emails to a single IMAP account

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Cheapest [proxies and servers](https://teletype.in/@web3enjoyer/4a2G9NuHssy) whi
    - `APPROVE_WALLET_ON_EMAIL = True`  # get approve link from email (NEEDED IMAP AND ACCESS TO EMAIL)
  - Provide emails and passwords and imap password (access to email) in format email:password:imap_password!
  - Need IMAP access to email
+ -  `SINGLE_IMAP_ACCOUNT = False `  # if you have possibility to forward all approve mails to single IMAP address. Usage: change False to "name@domain.com:password" of your main IMAP address
  -  `EMAIL_FOLDER = "" `  # skip for auto, folder where mails comes
  -  `IMAP_DOMAIN = "" `  # skip for auto domain, not always works
 

--- a/core/utils/mail.py
+++ b/core/utils/mail.py
@@ -5,12 +5,15 @@ from typing import Optional, Dict
 from imap_tools import MailBox, AND
 from loguru import logger
 
-from data.config import EMAIL_FOLDER, IMAP_DOMAIN
+from data.config import EMAIL_FOLDER, IMAP_DOMAIN, SINGLE_IMAP_ACCOUNT
 
 
 class MailUtils:
     def __init__(self, email: str, imap_pass: str) -> None:
-        self.email: str = email
+        if SINGLE_IMAP_ACCOUNT:
+            self.email: str = SINGLE_IMAP_ACCOUNT.split(":")[0]
+        else:
+            self.email: str = email
         self.imap_pass: str = imap_pass
         self.domain: str = IMAP_DOMAIN or self.parse_domain()
 

--- a/data/config.py
+++ b/data/config.py
@@ -2,11 +2,13 @@ THREADS = 1  # for register account / claim rewards mode / approve email mode
 MIN_PROXY_SCORE = 50  # for mining mode
 
 #########################################
-
 APPROVE_EMAIL = True  # approve email (NEEDED IMAP AND ACCESS TO EMAIL)
 CONNECT_WALLET = True  # connect wallet (put private keys in wallets.txt)
 SEND_WALLET_APPROVE_LINK_TO_EMAIL = True  # send approve link to email
 APPROVE_WALLET_ON_EMAIL = True  # get approve link from email (NEEDED IMAP AND ACCESS TO EMAIL)
+
+# If you have possibility to forward all approve mails to single IMAP address:
+SINGLE_IMAP_ACCOUNT = False # usage "name@domain.com:password"
 
 # skip for auto chosen
 EMAIL_FOLDER = ""  # folder where mails comes

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from core.utils.exception import EmailApproveLinkNotFoundException
 from core.utils.generate.person import Person
 from data.config import ACCOUNTS_FILE_PATH, PROXIES_FILE_PATH, REGISTER_ACCOUNT_ONLY, THREADS, REGISTER_DELAY, \
     CLAIM_REWARDS_ONLY, APPROVE_EMAIL, APPROVE_WALLET_ON_EMAIL, MINING_MODE, CONNECT_WALLET, \
-    WALLETS_FILE_PATH, SEND_WALLET_APPROVE_LINK_TO_EMAIL
+    WALLETS_FILE_PATH, SEND_WALLET_APPROVE_LINK_TO_EMAIL, SINGLE_IMAP_ACCOUNT
 
 
 def bot_info(name: str = ""):
@@ -35,6 +35,9 @@ def bot_info(name: str = ""):
 async def worker_task(_id, account: str, proxy: str = None, wallet: str = None, db: AccountsDB = None):
     consumables = account.split(":")[:3]
     imap_pass = None
+    
+    if SINGLE_IMAP_ACCOUNT:
+        consumables.append(SINGLE_IMAP_ACCOUNT.split(":")[1])
 
     if len(consumables) == 1:
         email = consumables[0]


### PR DESCRIPTION
If the user can forward all approval emails to one main IMAP account, he can use the `SINGLE_IMAP_ACCOUNT` feature.

This feature is especially useful for users who cannot use IMAP for all accounts but can forward emails to a main account.