### PR TITLE
Feature/ Semi-automatic email approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Cheapest [proxies and servers](https://teletype.in/@web3enjoyer/4a2G9NuHssy) whi
    - `APPROVE_WALLET_ON_EMAIL = True`  # get approve link from email (NEEDED IMAP AND ACCESS TO EMAIL)
  - Provide emails and passwords and imap password (access to email) in format email:password:imap_password!
  - Need IMAP access to email
+ -  `SEMI_AUTOMATIC_APPROVE_LINK = False `  # If True, allows manual pasting of the approval link from the email to the CLI. All flags above need to be set to True. If you use this flag, you do not need to provide IMAP access
  -  `SINGLE_IMAP_ACCOUNT = False `  # if you have possibility to forward all approve mails to single IMAP address. Usage: change False to "name@domain.com:password" of your main IMAP address
  -  `EMAIL_FOLDER = "" `  # skip for auto, folder where mails comes
  -  `IMAP_DOMAIN = "" `  # skip for auto domain, not always works

--- a/core/grass_sdk/website.py
+++ b/core/grass_sdk/website.py
@@ -16,6 +16,9 @@ from core.utils.mail import MailUtils
 from core.utils.session import BaseClient
 from solders.keypair import Keypair
 
+from data.config import SEMI_AUTOMATIC_APPROVE_LINK
+
+
 try:
     from data.config import REF_CODE
 except ImportError:
@@ -276,9 +279,13 @@ Nonce: {timestamp}"""
 
     async def get_email_approve_token(self, imap_pass: str, email_subject: str) -> str:
         logger.info(f"{self.id} | {self.email} Getting email approve msg...")
-        mail_utils = MailUtils(self.email, imap_pass)
-        result = await mail_utils.get_msg_async(to=self.email, from_="support@wynd.network",
-                                                subject=email_subject)
+        if SEMI_AUTOMATIC_APPROVE_LINK:
+            result['success'] = True
+            result['msg'] = input("Please, enter the email link: ").strip()
+        else:
+            mail_utils = MailUtils(self.email, imap_pass)
+            result = await mail_utils.get_msg_async(to=self.email, from_="support@wynd.network",
+                                                    subject=email_subject)
 
         if result['success']:
             verify_token = result['msg'].split('token=')[1].split('/')[0]

--- a/core/grass_sdk/website.py
+++ b/core/grass_sdk/website.py
@@ -280,8 +280,8 @@ Nonce: {timestamp}"""
     async def get_email_approve_token(self, imap_pass: str, email_subject: str) -> str:
         logger.info(f"{self.id} | {self.email} Getting email approve msg...")
         if SEMI_AUTOMATIC_APPROVE_LINK:
-            result['success'] = True
-            result['msg'] = input("Please, enter the email link: ").strip()
+            result = {'success': True}
+            result['msg'] = input(f"Please, paste approve link from {self.email} and press Enter: ").strip()
         else:
             mail_utils = MailUtils(self.email, imap_pass)
             result = await mail_utils.get_msg_async(to=self.email, from_="support@wynd.network",

--- a/data/config.py
+++ b/data/config.py
@@ -6,7 +6,7 @@ APPROVE_EMAIL = True  # approve email (NEEDED IMAP AND ACCESS TO EMAIL)
 CONNECT_WALLET = True  # connect wallet (put private keys in wallets.txt)
 SEND_WALLET_APPROVE_LINK_TO_EMAIL = True  # send approve link to email
 APPROVE_WALLET_ON_EMAIL = True  # get approve link from email (NEEDED IMAP AND ACCESS TO EMAIL)
-
+SEMI_AUTOMATIC_APPROVE_LINK = False # if True - allow to manual paste approve link from email to cli
 # If you have possibility to forward all approve mails to single IMAP address:
 SINGLE_IMAP_ACCOUNT = False # usage "name@domain.com:password"
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from core.utils.exception import EmailApproveLinkNotFoundException
 from core.utils.generate.person import Person
 from data.config import ACCOUNTS_FILE_PATH, PROXIES_FILE_PATH, REGISTER_ACCOUNT_ONLY, THREADS, REGISTER_DELAY, \
     CLAIM_REWARDS_ONLY, APPROVE_EMAIL, APPROVE_WALLET_ON_EMAIL, MINING_MODE, CONNECT_WALLET, \
-    WALLETS_FILE_PATH, SEND_WALLET_APPROVE_LINK_TO_EMAIL, SINGLE_IMAP_ACCOUNT
+    WALLETS_FILE_PATH, SEND_WALLET_APPROVE_LINK_TO_EMAIL, SINGLE_IMAP_ACCOUNT, SEMI_AUTOMATIC_APPROVE_LINK
 
 
 def bot_info(name: str = ""):
@@ -70,7 +70,9 @@ async def worker_task(_id, account: str, proxy: str = None, wallet: str = None, 
                 if user_info['result']['data'].get("isVerified"):
                     logger.info(f"{grass.id} | {grass.email} email already verified!")
                 else:
-                    if imap_pass is None:
+                    if SEMI_AUTOMATIC_APPROVE_LINK:
+                        imap_pass = "placeholder"
+                    elif imap_pass is None:
                         raise TypeError("IMAP password is not provided")
                     await grass.confirm_email(imap_pass)
             if CONNECT_WALLET:
@@ -85,7 +87,9 @@ async def worker_task(_id, account: str, proxy: str = None, wallet: str = None, 
                 if SEND_WALLET_APPROVE_LINK_TO_EMAIL:
                     await grass.send_approve_link(endpoint="sendWalletAddressEmailVerification")
                 if APPROVE_WALLET_ON_EMAIL:
-                    if imap_pass is None:
+                    if SEMI_AUTOMATIC_APPROVE_LINK:
+                        imap_pass = "placeholder"
+                    elif imap_pass is None:
                         raise TypeError("IMAP password is not provided")
                     await grass.confirm_wallet_by_email(imap_pass)
         elif CLAIM_REWARDS_ONLY:


### PR DESCRIPTION
Added flag `SEMI_AUTOMATIC_APPROVE_LINK` to `data/config.py`. If True, allows manual pasting of the approval link from the email to the CLI. 

This Feature can be useful for users who do not have IMAP access and have to do everything manually. It will help them save at least a small amount of time.