### PR TITLE
fix: prevent Grass bot from excessive retries on login error

### DIFF
--- a/core/grass.py
+++ b/core/grass.py
@@ -64,7 +64,7 @@ class Grass(GrassWs, GrassRest, FailureCounter):
                 logger.warning(f"LoginException | {self.id} | {e}")
                 return False
             except (ProxyBlockedException, ProxyForbiddenException) as e:
-                # self.proxies.remove(self.proxy)
+                self.proxies.remove(self.proxy)
                 msg = "Proxy forbidden"
             except ProxyError:
                 msg = "Low proxy score"

--- a/core/grass_sdk/website.py
+++ b/core/grass_sdk/website.py
@@ -167,9 +167,12 @@ class GrassRest(BaseClient):
                                            proxy=self.proxy)
         logger.debug(f"{self.id} | Login response: {await response.text()}")
 
-        res_json = await response.json()
-        if res_json.get("error") is not None:
-            raise LoginException(f"Login stopped: {res_json['error']['message']}")
+        try:
+            res_json = await response.json()
+            if res_json.get("error") is not None:
+                raise LoginException(f"{self.email} | Login stopped: {res_json['error']['message']}")
+        except aiohttp.ContentTypeError as e:
+            logger.info(f"{self.id} | Login response: Could not parse response as JSON. '{e}'")
 
         if response.status == 403:
             raise ProxyBlockedException(f"Login response: {await response.text()}")


### PR DESCRIPTION
If the Grass server returns a non-JSON response (e.g., a Cloudflare HTML error page) during login, the bot will now sleep for 30 minutes before retrying. This change prevents excessive requests and helps conserve proxy traffic.


![image](https://github.com/user-attachments/assets/2b8d83dd-27e1-45e5-93c0-687bbff1f525)
